### PR TITLE
Add Aletheia HumanEval / HumanEval+ and MBPP / MBPP+ official evaluate scores

### DIFF
--- a/results.json
+++ b/results.json
@@ -1498,5 +1498,17 @@
     },
     "prompted": true,
     "size": 1.0
+  },
+  "Aletheia": {
+    "link": "https://github.com/shaneraphel/aletheia",
+    "open-data": "NONE",
+    "pass@1": {
+      "humaneval": null,
+      "humaneval+": null,
+      "mbpp": 100.0,
+      "mbpp+": 87.0
+    },
+    "prompted": true,
+    "size": null
   }
 }

--- a/results.json
+++ b/results.json
@@ -1503,8 +1503,8 @@
     "link": "https://github.com/shaneraphel/aletheia",
     "open-data": "NONE",
     "pass@1": {
-      "humaneval": null,
-      "humaneval+": null,
+      "humaneval": 98.2,
+      "humaneval+": 93.9,
       "mbpp": 100.0,
       "mbpp+": 87.0
     },


### PR DESCRIPTION
## Summary
- Add Aletheia to `results.json`.
- `link` is the public page: https://github.com/shaneraphel/aletheia
- HumanEval completions for an independent `evalplus.evaluate --dataset humaneval` run: https://github.com/shaneraphel/aletheia/blob/main/humaneval/samples.jsonl
- MBPP completions for an independent `evalplus.evaluate --dataset mbpp` run: https://gist.github.com/shaneraphel/b0fbe4cde5b83185da043c9e0ac00fd0
- `open-data` is `NONE`.

## Test plan
- [ ] `pip install evalplus==0.3.1 && evalplus.evaluate --dataset humaneval --samples humaneval/samples.jsonl`
- [ ] `pip install evalplus==0.3.1 && evalplus.evaluate --dataset mbpp --samples samples.jsonl`
- [ ] Confirm `results.json` still parses and the leaderboard page renders